### PR TITLE
fix: use .Chart.AppVersion instead of .Chart.Version

### DIFF
--- a/helm/auth-bundle/Chart.yaml
+++ b/helm/auth-bundle/Chart.yaml
@@ -6,6 +6,7 @@ icon: https://s.giantswarm.io/app-icons/athena/1/light.svg
 sources:
   - https://github.com/giantswarm/auth-bundle
 version: 0.6.0
+appVersion: 0.6.0
 annotations:
   io.giantswarm.application.audience: all
   io.giantswarm.application.managed: "true"

--- a/helm/auth-bundle/templates/_helpers.tpl
+++ b/helm/auth-bundle/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/part-of: {{ include "name" . | quote }}
-app.kubernetes.io/version: {{ .Chart.Version | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 giantswarm.io/cluster: {{ .Values.clusterID | quote }}
 giantswarm.io/managed-by: {{ .Release.Name | quote }}
 giantswarm.io/organization: {{ .Values.organization | quote }}


### PR DESCRIPTION
Flux helm-controller appends hash with + sign at the end of .Chart.Version which makes it an invalid label value. Architect stores the same version under .Chart.AppVersion that is untouched by the controller.
